### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Ignore everything
+**
+
+# Except examples
+!/magine/examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM continuumio/miniconda:4.7.12
+
+RUN conda config --add channels conda-forge
+RUN conda install jinja2 statsmodels networkx graphviz pip python=3.7
+RUN conda install -c marufr python-igraph
+RUN pip install magine
+
+RUN useradd -ms /bin/bash magine
+USER magine
+WORKDIR /home/magine
+
+COPY magine/examples /home/magine/examples
+
+EXPOSE 8888
+ENTRYPOINT ["jupyter", "notebook", "--ip=*", "--no-browser"]


### PR DESCRIPTION
Adds a Dockerfile to create a MAGINE Docker container with
Jupyter Notebook. Example invocation:

    docker build -t magine .
    docker run --rm -v ~/magine-notebooks:/home/magine/notebooks -p 8888:8888 magine