### PR TITLE
Fixes for Dockerhub build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,2 @@
-# Ignore everything
-**
-
-# Except examples
-!magine/examples
+.git
+_sample_databases

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,4 @@
 **
 
 # Except examples
-!/magine/examples
+!magine/examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM continuumio/miniconda:4.7.12
 
+RUN conda config --add channels conda-forge
+RUN conda install jinja2 statsmodels networkx graphviz pip python=3.7
+RUN conda install -c marufr python-igraph
+RUN pip install magine
+
 RUN useradd -ms /bin/bash magine
 USER magine
 WORKDIR /home/magine
 
 COPY magine/examples /home/magine/examples
-
-RUN conda config --add channels conda-forge
-RUN conda install jinja2 statsmodels networkx graphviz pip python=3.7
-RUN conda install -c marufr python-igraph
-RUN python setup.py install
 
 EXPOSE 8888
 ENTRYPOINT ["jupyter", "notebook", "--ip=*", "--no-browser"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM continuumio/miniconda:4.7.12
 
 RUN conda config --add channels conda-forge
-RUN conda install jinja2 statsmodels networkx graphviz pip python=3.7
+RUN conda install jinja2 statsmodels networkx graphviz pip python=3.7 matplotlib
 RUN conda install -c marufr python-igraph
-RUN pip install magine
+
+RUN mkdir /tmp/magine-build
+COPY setup.py setup.cfg README.rst /tmp/magine-build/
+COPY docs /tmp/magine-build/docs/
+COPY scripts /tmp/magine-build/scripts/
+COPY magine/*[^examples] /tmp/magine-build/magine/
+RUN cd /tmp/magine-build && python setup.py install
 
 RUN useradd -ms /bin/bash magine
 USER magine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
 FROM continuumio/miniconda:4.7.12
 
-RUN conda config --add channels conda-forge
-RUN conda install jinja2 statsmodels networkx graphviz pip python=3.7
-RUN conda install -c marufr python-igraph
-RUN pip install magine
+RUN pwd
+RUN ls
 
 RUN useradd -ms /bin/bash magine
 USER magine
 WORKDIR /home/magine
 
+RUN pwd
+RUN ls
+
 COPY magine/examples /home/magine/examples
+
+RUN conda config --add channels conda-forge
+RUN conda install jinja2 statsmodels networkx graphviz pip python=3.7
+RUN conda install -c marufr python-igraph
+RUN python setup.py install
 
 EXPOSE 8888
 ENTRYPOINT ["jupyter", "notebook", "--ip=*", "--no-browser"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
 FROM continuumio/miniconda:4.7.12
 
-RUN pwd
-RUN ls
-
 RUN useradd -ms /bin/bash magine
 USER magine
 WORKDIR /home/magine
-
-RUN pwd
-RUN ls
 
 COPY magine/examples /home/magine/examples
 

--- a/Dockerfile.complete
+++ b/Dockerfile.complete
@@ -1,0 +1,3 @@
+FROM lolab/magine
+
+RUN download_magine_databases


### PR DESCRIPTION
Fixes to Docker Hub build. Add an additional `Dockerfile.complete`,
which incorporates databases into the Docker build.